### PR TITLE
Added a 'club how-to' navlink

### DIFF
--- a/partials/nav.php
+++ b/partials/nav.php
@@ -22,6 +22,7 @@
       <li><a href='history.php'>History</a></li>
       <li><a href='codingchallenges.php'>Challenges</a></li>
       <li><a href='lightningtalks.php'>Talks</a></li>
+      <li><a href='https://github.com/CCSF-Coders/club-how-to/wiki'>Club How To</a></li>
     </ul>
   </div>
   <!-- index.php# pager used so if we're already on index.php, we don't

--- a/partials/quicklinks.php
+++ b/partials/quicklinks.php
@@ -7,5 +7,6 @@
   <a href="https://www.youtube.com/user/CCSFCoders" target="_blank" id="social-youtube"><i class="fa fa-youtube-square"></i></a>
   <a href="https://groups.google.com/forum/#!forum/ccsfcoders" target="_blank" id="social-googlegroup"><i class="fa fa-google"></i></a>
   <a href="https://twitter.com/ccsfcoders" target="_blank" id="social-twitter"><i class="fa fa-twitter-square"></i></a>
+  <a href="https://ccsfcodersclub.slack.com" target="_blank" id="social-slack"><i class="fa fa-slack" aria-hidden="true"></i></a>
 </div>
 <!-- End quicklinks.php -->


### PR DESCRIPTION
![screen shot 2016-09-19 at 6 15 53 pm](https://cloud.githubusercontent.com/assets/1417341/18654367/61648f04-7e95-11e6-9161-939ad72d8a28.png)

from @kmolo:

```
One of the things we had talked about in the past was adding the Club "How-To" wiki:

https://github.com/CCSF-Coders/club-how-to/wiki

...to the website nav bar links.

The idea being that that way:

- our entire membership can see how things are done, empowering everyone, not just the current/past officers to organize things for the club

- transition to new members is easier for outgoing officers
```
